### PR TITLE
update java dependency to resolve npm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "async": "~1.5.0",
-    "java": "~0.9.0"
+    "java": "^0.11.1"
   },
 "devDependencies": {
     "mocha": "~2.0.1",


### PR DESCRIPTION
When doing a vanilla install of jmx I get `found 4 high severity vulnerabilities` from npm. It's from the `java` dependency.

I've been using the 0.11 npm-java version here for a few months and things seem to be fine.
