### PR TITLE
Feature enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ lib-cov
 *.pid
 *.gz
 coverage.html
+/dev
+package-lock.json
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of `jmx` Node.js module.
 
+## 0.8.0 (2020-03-20)
+
+* Update NPM modules
+* All APIs now return Promise, except the API inherited from EventEmitter
+* Add new API "queryNamesWithObjectName" w.r.t. "queryNames" in "MBeanServerConnection", with only "ObjectName" is support.
+
 ## 0.7.0 (2018-03-25)
 
 * Update `java` dependency to `~0.9.0` ([issue #16](https://github.com/zuazo/node-jmx/issues/16), thanks [DarkSorrow](https://github.com/DarkSorrow)).

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Adds a listener for the especified event.
 
 ### Client.queryNamesWithObjectName(objectNameSearchString)
 
-Search names with object name query, referring to [MBeanServerConnection.queryNames](https://docs.oracle.com/javase/7/docs/api/javax/management/MBeanServerConnection.html#queryNames(javax.management.ObjectName,%20javax.management.QueryExp)
+Search names with object name query, referring to [MBeanServerConnection.queryNames](https://docs.oracle.com/javase/7/docs/api/javax/management/MBeanServerConnection.html#queryNames)
 
 #### events
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Lists server MBeans. Callback returns an array of strings containing MBean names
 
 Adds a listener for the especified event.
 
+### Client.queryNamesWithObjectName(objectNameSearchString)
+
+Search names with object name query, referring to [MBeanServerConnection.queryNames](https://docs.oracle.com/javase/7/docs/api/javax/management/MBeanServerConnection.html#queryNames(javax.management.ObjectName,%20javax.management.QueryExp)
+
 #### events
 
 * `connect`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # node-jmx
 
+This is a fork of node-jmx modified by Kay Chan. Please checkout "0.8.0" in change log for the changes of this fork.
+
 [![NPM version](https://badge.fury.io/js/jmx.svg)](http://badge.fury.io/js/jmx)
 [![Code Climate](https://img.shields.io/codeclimate/maintainability-percentage/zuazo/node-jmx.svg)](https://codeclimate.com/github/zuazo/node-jmx)
 [![Build Status](http://img.shields.io/travis/zuazo/node-jmx.svg)](https://travis-ci.org/zuazo/node-jmx)
@@ -28,30 +30,28 @@ client = jmx.createClient({
 });
 
 client.connect();
-client.on("connect", function() {
+client.on("connect", run);
 
-  client.getAttribute("java.lang:type=Memory", "HeapMemoryUsage", function(data) {
-    var used = data.getSync('used');
-    console.log("HeapMemoryUsage used: " + used.longValue);
-    // console.log(data.toString());
-  });
+async function run () {
+  let data = await client.getAttribute("java.lang:type=Memory", "HeapMemoryUsage");
+  var used = data.getSync('used');
+  console.log("HeapMemoryUsage used: " + used.longValue);
 
-  client.setAttribute("java.lang:type=Memory", "Verbose", true, function() {
-    console.log("Memory verbose on"); // callback is optional
-  });
+  await client.setAttribute("java.lang:type=Memory", "Verbose", true);
+  console.log("Memory verbose on");
 
-  client.invoke("java.lang:type=Memory", "gc", [], function(data) {
-    console.log("gc() done");
-  });
-
-});
+  await client.invoke("java.lang:type=Memory", "gc", []);
+  console.log("gc() done");
+}
 ```
 
+Client can be created by service URL instead:
 ```js
 client = jmx.createClient({
   service: "service:jmx:rmi:///jndi/rmi://localhost:3000/jmxrmi"
 });
 ```
+
 You can check the [node-java documentation](https://github.com/nearinfinity/node-java/blob/master/README.md#quick-examples) to learn how to work with java objects in node.js.
 
 ## Documentation
@@ -80,7 +80,7 @@ Connects to the JMX server. Emits `connect` event when done.
 
 Disconnects from the JMX server. Emits `disconnect` event when done.
 
-### Client.getAttribute(mbean, attribute, callback)
+### Client.getAttribute(mbean, attribute)
 
 Returns an attribute from a MBean.
 
@@ -88,7 +88,7 @@ Returns an attribute from a MBean.
 * `attribute` - Attribute name as string.
 * `callback(attrValue)`
 
-### Client.getAttributes(mbean, attributes, callback)
+### Client.getAttributes(mbean, attributes)
 
 Returns an attribute list from a MBean.
 
@@ -96,25 +96,25 @@ Returns an attribute list from a MBean.
 * `attributes` - Attribute names as an array of strings.
 * `callback(attrValue)`
 
-### Client.getDefaultDomain(callback)
+### Client.getDefaultDomain()
 
 Returns the default domain as string.
 
 * `callback(domainName)`
 
-### Client.getDomains(callback)
+### Client.getDomains()
 
 Returns an array of domain names.
 
 * `callback(domainsArray)`
 
-### Client.getMBeanCount(callback)
+### Client.getMBeanCount()
 
 Returns total the number of MBeans.
 
 * `callback(mbeanCount)`
 
-### Client.invoke(mbean, methodName, params, [signature,] [callback])
+### Client.invoke(mbean, methodName, params, [signature])
 
 Invokes a MBean operation.
 
@@ -124,7 +124,7 @@ Invokes a MBean operation.
 * `signature` (optional) - An array with the signature of the *params*. Sometimes may be necessary to use this if class names are not correctly detected (gives a *NoSuchMethodException*). For example `[ "int", "java.lang.Integer", "java.lang.String" ]`.
 * `callback(returnedValue)`
 
-### Client.listMBeans(callback)
+### Client.listMBeans()
 
 Lists server MBeans. Callback returns an array of strings containing MBean names.
 
@@ -138,7 +138,7 @@ Adds a listener for the especified event.
 * `disconnect`
 * `error` - Passes the error as first parameter to the callback function.
 
-### Client.setAttribute(mbean, attribute, value, [className,] [callback])
+### Client.setAttribute(mbean, attribute, value, [className])
 
 Changes an attribute value of the MBean.
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Client = require("./lib/client"),
+var Client = require("./lib/client2"),
     assert = require("assert");
 
 function createClient(options) {

--- a/lib/adapters/mbeanServerConnection.js
+++ b/lib/adapters/mbeanServerConnection.js
@@ -108,6 +108,22 @@ MBeanServerConnection.prototype.getAttribute = function(name, attribute, callbac
   );
 };
 
+// Gets the names of MBeans by ObjectName without query
+MBeanServerConnection.prototype.queryNamesWithObjectName = function(name, callback) {
+  // TODO: confirm about ObjectMame
+  this.javaReflection.invokeMethod(
+    this.mbeanServerConnection,
+    'queryNames',
+    [ "javax.management.ObjectName", "javax.management.QueryExp" ], // methodParamsClass
+    [ name, null ], // methodParams
+    function (data) {
+      // convert data to string array
+      const result = data.toArraySync().map(d => d.toStringSync());
+      callback(result);
+    }
+  );
+};
+
 MBeanServerConnection.prototype.getDefaultDomain = function(callback) {
   this.javaReflection.invokeMethod(
     this.mbeanServerConnection,

--- a/lib/client.js
+++ b/lib/client.js
@@ -45,6 +45,10 @@ Client.prototype.getAttribute = function(mbean, attribute, callback) {
   this.javaJmx.getAttribute(mbean, attribute, callback);
 };
 
+Client.prototype.queryNamesWithObjectName = function(attribute, callback) {
+  this.javaJmx.queryNamesWithObjectName(attribute, callback);
+};
+
 Client.prototype.getDefaultDomain = function(callback) {
   this.javaJmx.getDefaultDomain(callback);
 };

--- a/lib/client2.js
+++ b/lib/client2.js
@@ -1,0 +1,132 @@
+var Client = require("./client")
+
+{
+  let tmp = Client.prototype.connect
+  Client.prototype.connect = tmp
+}
+
+{
+  let tmp = Client.prototype.disconnect
+  Client.prototype.disconnect = tmp
+}
+
+{
+  let tmp = Client.prototype.getAttributes
+  Client.prototype.getAttributes = function(mbean, attributes) {
+    return new Promise((resolve, reject) => {
+      try {
+        tmp.apply(this, [mbean, attributes, resolve])
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+}
+
+{
+  let tmp = Client.prototype.getAttribute
+  Client.prototype.getAttribute = function(mbean, attributes) {
+    return new Promise((resolve, reject) => {
+      try {
+        tmp.apply(this, [mbean, attributes, resolve])
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+}
+
+{
+  let tmp = Client.prototype.queryNamesWithObjectName
+  Client.prototype.queryNamesWithObjectName = function(attribute) {
+    return new Promise((resolve, reject) => {
+      try {
+        tmp.apply(this, [attribute, resolve])
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+}
+
+// TODO:
+{
+  let tmp = Client.prototype.getDefaultDomain
+  Client.prototype.getDefaultDomain = function() {
+    return new Promise((resolve, reject) => {
+      try {
+        tmp.apply(this, [resolve])
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+}
+
+{
+  let tmp = Client.prototype.getDomains
+  Client.prototype.getDomains = function() {
+    return new Promise((resolve, reject) => {
+      try {
+        tmp.apply(this, [resolve])
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+}
+
+{
+  let tmp = Client.prototype.getMBeanCount
+  Client.prototype.getMBeanCount = function() {
+    return new Promise((resolve, reject) => {
+      try {
+        tmp.apply(this, [resolve])
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+}
+
+{
+  let tmp = Client.prototype.invoke
+  Client.prototype.invoke = function(mbean, methodName, params, signatureOrCallback) {
+    return new Promise((resolve, reject) => {
+      try {
+        tmp.apply(this, [mbean, methodName, params, signatureOrCallback, resolve])
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+}
+
+{
+  let tmp = Client.prototype.listMBeans
+  Client.prototype.listMBeans = function() {
+    return new Promise((resolve, reject) => {
+      try {
+        tmp.apply(this, [resolve])
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+}
+
+{
+  let tmp = Client.prototype.setAttribute
+  Client.prototype.setAttribute = function(mbean, attribute, value, classNameOrCallback) {
+    return new Promise((resolve, reject) => {
+      try {
+        tmp.apply(this, [mbean, attribute, value, classNameOrCallback, resolve])
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+}
+
+
+module.exports = Client;

--- a/lib/javaJmx.js
+++ b/lib/javaJmx.js
@@ -78,6 +78,12 @@ JavaJmx.prototype.getAttribute = function(mbean, attributeName, callback) {
   });
 };
 
+JavaJmx.prototype.queryNamesWithObjectName = function(objectNameStr, callback) {
+  var self = this;
+  var objectName = java.newInstanceSync("javax.management.ObjectName", objectNameStr);
+  self.mbeanServerConnection.queryNamesWithObjectName(objectName, callback);
+}
+
 JavaJmx.prototype.getDefaultDomain = function(callback) {
   this.mbeanServerConnection.getDefaultDomain(callback);
 };

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "async": "~1.5.0",
-    "java": "~0.9.0"
+    "async": "^3.2.0",
+    "java": "~0.12.1"
   },
-"devDependencies": {
+  "devDependencies": {
     "mocha": "~2.0.1",
-    "jscoverage" : "~0.5.9",
-    "mocha-lcov-reporter" : "0.0.1",
+    "jscoverage": "~0.5.9",
+    "mocha-lcov-reporter": "0.0.1",
     "coveralls": "2.11.2"
   }
 }


### PR DESCRIPTION
* Update NPM modules
* All APIs now return Promise, except the API inherited from EventEmitter
* Add new API "queryNamesWithObjectName" w.r.t. "queryNames" in "MBeanServerConnection", with only "ObjectName" is support.